### PR TITLE
Hide sidebar links on mobile

### DIFF
--- a/.vuepress/styles/index.styl
+++ b/.vuepress/styles/index.styl
@@ -14,3 +14,7 @@
     background-size 20px 20px
     height 20px
     width 20px
+
+.theme-container.no-sidebar
+  .sidebar-links
+    display none


### PR DESCRIPTION
You can disable the sidebar on some pages through configuration. We use this for the home and for the index. The current theme hides the sidebar, but only on large screens.

https://github.com/vuejs/vuepress/blob/5d6adf1f2555180104f305390bfced433aeab279/packages/%40vuepress/theme-default/styles/index.styl#L193-L196

It kinda makes sense because the sidebar on mobile is used also to put up links to pages. It's an issue for others as well https://github.com/vuejs/vuepress/issues/1467

Unfortunately, because we use generic titles for sections now, it's awful on a smartphone.
![Screenshot+2020-01-13+at+21 56 15](https://user-images.githubusercontent.com/295709/72291746-47511080-3650-11ea-91ad-bc2117dd6e4a.png)

This PR hides only the sidebar links and not the upper part of the sidebar. I think it's specific to this repo and shouldn't be needed in our custom theme.