### PR TITLE
Schémas : lien vers template

### DIFF
--- a/producteurs-schemas/3-phase-construction.md
+++ b/producteurs-schemas/3-phase-construction.md
@@ -40,7 +40,9 @@ Une fois un standard technique choisi, il faudra créer les fichiers requis pour
 Il est souvent possible de vérifier qu’un fichier correspond à un standard à l’aide d’outils en ligne ou en ligne de commande. Utilisez ces outils pour vérifier que vos productions correspondent au standard.
 
 ::: tip Exemples à votre disposition
-Nous vous conseillons vivement de partir d’un schéma de données existant. Vous pouvez parcourir ces exemples sur [schema.data.gouv.fr](https://schema.data.gouv.fr) pour faciliter votre travail. Consultez par exemple [le fichier TableSchema décrivant les lieux de stationnement](https://schema.data.gouv.fr/schemas/etalab/schema-stationnement/latest/schema.json).
+Pour un schéma au format Table Schema, nous mettons à votre disposition [un modèle de départ](https://github.com/etalab/tableschema-template) pour créer un dépôt Git contenant un schéma au format Table Schema.
+
+Pour les autres formats de schémas, nous vous recommandons de consulter les schémas et dépôts Git listés sur [schema.data.gouv.fr](https://schema.data.gouv.fr).
 :::
 
 ## Documenter votre schéma de données


### PR DESCRIPTION
Ajoute un lien vers le dépôt contenant le template Table Schema

---

PS : @etalab/schema-data-gouv-fr devrait être automatiquement assigné en tant que reviewer mais ce n'est pas le cas.

https://github.com/etalab/guides.etalab.gouv.fr/blob/96a208f64d3a315fcffb0e48a48cce99b670ede4/.github/CODEOWNERS#L14

Je pense qu'il faut mettre explicitement des permissions d'écriture pour cette équipe sur ce dépôt.
> The people you choose as code owners must have write permissions for the repository. When the code owner is a team, that team must have write permissions, even if all the individual members of the team already have write permissions directly, through organization membership, or through another team membership.

From [the documentation](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners)