### PR TITLE
Mode d'emploi CSV-GG en texte au lieu d'une image

### DIFF
--- a/qualite/1-preparer-le-jeu-de-donnees.md
+++ b/qualite/1-preparer-le-jeu-de-donnees.md
@@ -57,7 +57,15 @@ Le site [schema.data.gouv.fr](http://schema.data.gouv.fr) référence une liste 
 
 Si le jeu de données n’est pas extrait d’un système d’information mais saisi manuellement, [l’outil CSV-GG](https://csv-gg.etalab.studio/?schema=etalab%2Fschema-decp-dpa) peut assister le processus de production. À partir d’un schéma de données sélectionné, il est possible de saisir les valeurs de chaque information et ainsi produire un fichier exhaustif et conforme.
 
-![Outil CSV-GG](./images/csv_gg.png)
+
+::: tip CSV-GG mode d'emploi
+Cet outil vous permet de créer un fichier CSV en vous assurant qu'il est conforme à un schéma, c'est-à-dire que ses données sont complètes, valides et structurées.
+1. Sélectionnez le schéma qui vous intéresse dans la liste déroulante, les schémas disponibles ici étant ceux référencés sur schema.data.gouv.fr.
+2. Remplissez le formulaire à l'aide des descriptions des différents champs et des valeurs d'exemples. Les champs indiqués par un astérisque rouge doivent obligatoirement être renseignés au moment de la saisie.
+3. L'outil vous prévient d'éventuelles erreurs de validation, le cas échéant vous pouvez les corriger.
+4. Une fois votre formulaire valide, les valeurs apparaissent sous la forme d'une ligne dans un tableau récapitulatif.
+5. Vous pouvez alors choisir d'ajouter une ou plusieurs lignes (répétez les étapes 2 à 4) ou télécharger le fichier CSV correspondant au tableau récapitulatif.
+:::
 
 
 #### Comment valider la conformité d’un jeu de données avec un schéma de données ?


### PR DESCRIPTION
Le mode d'emploi de CSV-GG étaient une image embedded, maintenant c'est du texte.